### PR TITLE
Restore default font size

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,15 +21,9 @@ body {
 
 html {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 400;
   line-height: 1.6;
-}
-
-@media (min-width: 38em) {
-  html {
-    font-size: 16px;
-  }
 }
 
 body {
@@ -147,7 +141,6 @@ img {
 .page-description {
     margin-bottom: 1.5rem;
     color: #515151;
-    font-size: 13px;
     line-height: 1.6;
 }
 
@@ -158,7 +151,6 @@ img {
 .content{
     padding-left: 30px;
     border-left: 1px solid #dedfe0;
-    font-size: 13px;
     flex: 1;
     min-width: 0;
 }


### PR DESCRIPTION
## Summary
- keep base font size at 16px so text no longer shrinks on load
- remove page description and main content font overrides for consistent default sizing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e05f6ee9c83279eb106d2e0c617d7