### PR TITLE
Reorder gallery to feature Black Bear first

### DIFF
--- a/photos/index.html
+++ b/photos/index.html
@@ -115,10 +115,10 @@
       
         <div class="photo-grid">
           <div class="photo-item">
-            <img src="src/Coquihalla Summit.jpeg" alt="Coquihalla Summit" loading="lazy">
+            <img src="src/Bear.jpg" alt="Black Bear" loading="lazy">
             <div class="photo-caption">
-              <div class="location">Coquihalla Summit</div>
-              <div class="description">British Columbia, Canada</div>
+              <div class="location">Black Bear</div>
+              <div class="description">Yosemite, California</div>
             </div>
           </div>
 
@@ -129,7 +129,7 @@
               <div class="description">Burlington, Vermont</div>
             </div>
           </div>
-          
+
           <div class="photo-item">
             <img src="src/Tokyo.jpg" alt="Tokyo" loading="lazy">
             <div class="photo-caption">
@@ -137,12 +137,12 @@
               <div class="description">Tokyo, Japan</div>
             </div>
           </div>
-          
+
           <div class="photo-item">
-            <img src="src/Bear.jpg" alt="Black Bear" loading="lazy">
+            <img src="src/Coquihalla Summit.jpeg" alt="Coquihalla Summit" loading="lazy">
             <div class="photo-caption">
-              <div class="location">Black Bear</div>
-              <div class="description">Yosemite, California</div>
+              <div class="location">Coquihalla Summit</div>
+              <div class="description">British Columbia, Canada</div>
             </div>
           </div>
           


### PR DESCRIPTION
## Summary
- move the Black Bear gallery tile into the lead position on the photos page
- shift the Coquihalla Summit photo down to the former Black Bear slot

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68d198c0d4188327991eb8dc43b3a266